### PR TITLE
Add a 0.6 nozzle profile

### DIFF
--- a/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
+++ b/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
@@ -16,7 +16,7 @@ config_update_url = https://files.prusa3d.com/wp-content/uploads/repository/Prus
 
 [printer_model:M5]
 name = AnkerMake M5
-variants = 0.4
+variants = 0.4; 0.6
 technology = FFF
 family = AnkerMake
 bed_model = M5-bed.stl
@@ -180,9 +180,31 @@ top_solid_layers = 4
 [print:*0.28mm*]
 inherits = *common*
 layer_height = 0.28
-first_layer_height = 0.28
+first_layer_height = 0.30
 bottom_solid_layers = 3
 top_solid_layers = 4
+
+[print:*0.30mm*]
+inherits = *common*
+layer_height = 0.30
+first_layer_height = 0.35
+bottom_solid_layers = 3
+top_solid_layers = 4
+
+[print:*0.40mm*]
+inherits = *common*
+layer_height = 0.40
+first_layer_height = 0.45
+bottom_solid_layers = 3
+top_solid_layers = 4
+
+[print:*0.45mm*]
+inherits = *common*
+layer_height = 0.45
+first_layer_height = 0.45
+bottom_solid_layers = 3
+top_solid_layers = 4
+
 
 [print:0.08 mm SUPERDETAIL (0.4 mm nozzle) @ANKER]
 inherits = *0.08mm*
@@ -212,6 +234,25 @@ compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==
 inherits = *0.28mm*
 compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.4
 
+[print:0.10 mm DETAIL (0.6 mm nozzle) @ANKER]
+inherits = *0.10mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
+
+[print:0.20 mm OPTIMAL (0.6 mm nozzle) @ANKER]
+inherits = *0.20mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
+
+[print:0.30 mm NORMAL (0.6 mm nozzle) @ANKER]
+inherits = *0.30mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
+
+[print:0.40 mm DRAFT (0.6 mm nozzle) @ANKER]
+inherits = *0.40mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
+
+[print:0.45 mm SUPERDRAFT (0.6 mm nozzle) @ANKER]
+inherits = *0.45mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
 
 # When submitting new filaments please print the following temperature tower at 0.1mm layer height:
 #   https://www.thingiverse.com/thing:2615842
@@ -400,3 +441,12 @@ min_layer_height = 0.08
 max_layer_height = 0.32
 retract_lift_above = 0.2
 default_print_profile = "0.16 mm OPTIMAL (0.4 mm nozzle) @ANKER"
+
+[printer:AnkerMake M5 (0.6 mm nozzle)]
+inherits = *M5*
+nozzle_diameter = 0.6
+printer_variant = 0.6
+min_layer_height = 0.1
+max_layer_height = 0.45
+retract_lift_above = 0.2
+default_print_profile = "0.20 mm OPTIMAL (0.6 mm nozzle) @ANKER"


### PR DESCRIPTION
Adds an "Alternate Nozzles" choice when selecting the M5
![image](https://user-images.githubusercontent.com/4044356/208514686-8ac38990-b088-4908-bb4f-93f80ec724ad.png)

Adds profiles that are better suitated for a 0.6 nozzle
![image](https://user-images.githubusercontent.com/4044356/208514764-049d376b-a792-4df4-8c9a-4463e70e670e.png)
