### PR TITLE
Slow down the top speed for 0.6mm profiles

### DIFF
--- a/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
+++ b/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
@@ -134,7 +134,7 @@ xy_size_compensation = 0
 [print:*0.08mm*]
 inherits = *common*
 layer_height = 0.08
-first_layer_height = 0.12
+first_layer_height = 0.08
 bottom_solid_layers = 9
 top_solid_layers = 11
 bridge_flow_ratio = 0.70
@@ -142,7 +142,7 @@ bridge_flow_ratio = 0.70
 [print:*0.10mm*]
 inherits = *common*
 layer_height = 0.10
-first_layer_height = 0.14
+first_layer_height = 0.08
 bottom_solid_layers = 7
 top_solid_layers = 9
 bridge_flow_ratio = 0.70
@@ -150,7 +150,7 @@ bridge_flow_ratio = 0.70
 [print:*0.12mm*]
 inherits = *common*
 layer_height = 0.12
-first_layer_height = 0.16
+first_layer_height = 0.10
 bottom_solid_layers = 6
 top_solid_layers = 7
 bridge_flow_ratio = 0.70
@@ -158,7 +158,7 @@ bridge_flow_ratio = 0.70
 [print:*0.16mm*]
 inherits = *common*
 layer_height = 0.16
-first_layer_height = 0.20
+first_layer_height = 0.12
 bottom_solid_layers = 5
 top_solid_layers = 7
 bridge_flow_ratio = 0.85
@@ -166,45 +166,30 @@ bridge_flow_ratio = 0.85
 [print:*0.20mm*]
 inherits = *common*
 layer_height = 0.20
-first_layer_height = 0.24
+first_layer_height = 0.16
 bottom_solid_layers = 4
 top_solid_layers = 5
 
 [print:*0.24mm*]
 inherits = *common*
 layer_height = 0.24
-first_layer_height = 0.28
+first_layer_height = 0.20
 bottom_solid_layers = 3
 top_solid_layers = 4
 
 [print:*0.28mm*]
 inherits = *common*
 layer_height = 0.28
-first_layer_height = 0.30
+first_layer_height = 0.24
 bottom_solid_layers = 3
 top_solid_layers = 4
 
 [print:*0.30mm*]
 inherits = *common*
 layer_height = 0.30
-first_layer_height = 0.35
+first_layer_height = 0.28
 bottom_solid_layers = 3
 top_solid_layers = 4
-
-[print:*0.40mm*]
-inherits = *common*
-layer_height = 0.40
-first_layer_height = 0.45
-bottom_solid_layers = 3
-top_solid_layers = 4
-
-[print:*0.45mm*]
-inherits = *common*
-layer_height = 0.45
-first_layer_height = 0.45
-bottom_solid_layers = 3
-top_solid_layers = 4
-
 
 [print:0.08 mm SUPERDETAIL (0.4 mm nozzle) @ANKER]
 inherits = *0.08mm*
@@ -242,17 +227,18 @@ compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==
 inherits = *0.20mm*
 compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
 
+# this printer isn't capable of printing at 250mm/s with the larger nozzle diameter, so we need to reduce the top speeds
+perimeter_speed = 225
+infill_speed = 225
+max_print_speed = 225
+
 [print:0.30 mm NORMAL (0.6 mm nozzle) @ANKER]
 inherits = *0.30mm*
 compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
-
-[print:0.40 mm DRAFT (0.6 mm nozzle) @ANKER]
-inherits = *0.40mm*
-compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
-
-[print:0.45 mm SUPERDRAFT (0.6 mm nozzle) @ANKER]
-inherits = *0.45mm*
-compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6
+# this printer isn't capable of printing at 250mm/s with the larger nozzle diameter, so we need to reduce the top speeds
+perimeter_speed = 200
+infill_speed = 200
+max_print_speed = 200
 
 # When submitting new filaments please print the following temperature tower at 0.1mm layer height:
 #   https://www.thingiverse.com/thing:2615842


### PR DESCRIPTION
Reduces the top print speed for the .2 and .3 profiles 
Removes the .4 and .45 profiles (the speed needed to be slowed down to the point where the print time was slower than the 0.3 profile) 
Fixes the first layer print height (it should have been smaller, not larger)