### PR TITLE
Adjust default PETG settings for cleaner prints

### DIFF
--- a/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
+++ b/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
@@ -356,6 +356,11 @@ filament_vendor = Generic
 [filament:Generic PETG @ANKER]
 inherits = *PET*
 filament_vendor = Generic
+cooling = 1
+max_fan_speed = 35
+min_fan_speed = 10
+filament_retract_length = 3
+filament_retract_speed = 10
 
 [filament:Generic ABS @ANKER]
 inherits = *ABS*


### PR DESCRIPTION
These are the general filament cooling and retraction settings I've found to be most helpful when printing with PETG. These prevent blobs on travel and massively reduce stringing.