### PR TITLE
'Easy Mode' PETG Printer Settings

### DIFF
--- a/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
+++ b/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
@@ -234,6 +234,23 @@ compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==
 inherits = *0.28mm*
 compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.4
 
+[print:0.20 mm EASY PETG (0.4 mm nozzle) @ANKER]
+inherits = *0.20mm*
+compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.4
+avoid_crossing_perimeters = 1
+external_perimeters_first = 1
+perimeter_speed = 0
+external_perimeter_speed = 0
+gap_fill_speed = 40
+bridge_speed = 30
+infill_speed = 0
+small_perimeter_speed = 0
+solid_infill_speed = 0
+support_material_speed = 80
+top_solid_infill_speed = 0
+max_volumetric_speed = 10
+top_infill_extrusion_width = 0.4
+
 [print:0.10 mm DETAIL (0.6 mm nozzle) @ANKER]
 inherits = *0.10mm*
 compatible_printers_condition = printer_model=~/(M5).*/ and nozzle_diameter[0]==0.6


### PR DESCRIPTION
Settings that will generate gcode based on an assumption of 12mm3/s volumetric speed of PETG (general average based on testing performed). Should be a solid 'no fuss' PETG printing profile, that people can then refine to their own needs.