### PR TITLE
Remove nozzle over-prime move from start G-Code

### DIFF
--- a/Cura-5.x-M5-Profile/definitions/ankermake_m5.def.json
+++ b/Cura-5.x-M5-Profile/definitions/ankermake_m5.def.json
@@ -59,7 +59,7 @@
         "machine_heated_bed": { "default_value": true },
         "machine_height": { "default_value": 250 },
         "machine_name": { "default_value": "AnkerMake M5" },
-        "machine_start_gcode": { "default_value": "M104 S{material_print_temperature_layer_0} ; set final nozzle temp\nM190 S{material_bed_temperature_layer_0} ; set and wait for bed temp to stabilize\nM109 S{material_print_temperature_layer_0} ; wait for nozzle temp to stabilize\nG28 ;Home\nM420 S1; restore saved Auto Bed Leveling data\nG1 E10 F3600; push out retracted filament(fix for over retraction after prime)" },
+        "machine_start_gcode": { "default_value": "M104 S{material_print_temperature_layer_0} ; set final nozzle temp\nM190 S{material_bed_temperature_layer_0} ; set and wait for bed temp to stabilize\nM109 S{material_print_temperature_layer_0} ; wait for nozzle temp to stabilize\nG28 ;Home\nM420 S1; restore saved Auto Bed Leveling data" },
         "machine_width": { "default_value": 235 },
         "material_bed_temperature": { "maximum_value_warning": "110" },
         "material_bed_temperature_layer_0": { "maximum_value_warning": "110" },

--- a/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
+++ b/PrusaSlicer-2.5-M5-Profile/vendor/AnkerMake.ini
@@ -418,7 +418,7 @@ variable_layer_height = 1
 wipe = 1
 z_offset = 0
 default_filament_profile = Generic PLA+ @ANKER
-start_gcode = M104 S{first_layer_temperature[0]} ; set final nozzle temp\nM190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize\nM109 S{first_layer_temperature[0]} ; wait for nozzle temp to stabilize\nG28 ;Home\nM420 S1; restore saved Auto Bed Leveling data\nG1 E10 F3600; push out retracted filament(fix for over retraction after prime)
+start_gcode = M104 S{first_layer_temperature[0]} ; set final nozzle temp\nM190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize\nM109 S{first_layer_temperature[0]} ; wait for nozzle temp to stabilize\nG28 ;Home\nM420 S1; restore saved Auto Bed Leveling data
 end_gcode = M104 S0\nM140 S0\n;Retract the filament\nG92 E1\nG1 E-1 F300\nG28 X0 Y0\nM84
 
 [printer:*M5*]


### PR DESCRIPTION
The old fix for Anker over-retracting the filament during homing is no longer needed. The homing behavior now correctly primes the nozzle and the old fix now causes a huge blob to come out of the nozzle just before the print starts. I've thoroughly tested this change with PLA and PETG and it works like a dream.